### PR TITLE
Fix common typo in docs

### DIFF
--- a/docs/10_0_0/components/ajaxbehavior.md
+++ b/docs/10_0_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/10_0_0/components/commandbutton.md
+++ b/docs/10_0_0/components/commandbutton.md
@@ -31,7 +31,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/10_0_0/components/commandlink.md
+++ b/docs/10_0_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/10_0_0/components/hotkey.md
+++ b/docs/10_0_0/components/hotkey.md
@@ -29,7 +29,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/10_0_0/components/menuitem.md
+++ b/docs/10_0_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/10_0_0/components/poll.md
+++ b/docs/10_0_0/components/poll.md
@@ -29,7 +29,7 @@ update | @none | String | Component(s) to be updated with ajax.
 listener | null | MethodExpr | A method expression to invoke by polling.
 immediate | false | Boolean | Boolean value that determines the phaseId, when true actions are processed at apply_request_values, when false at invoke_application phase.
 async | false | Boolean | When set to true, ajax requests are not queued.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/10_0_0/components/remotecommand.md
+++ b/docs/10_0_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/10_0_0/components/splitbutton.md
+++ b/docs/10_0_0/components/splitbutton.md
@@ -31,7 +31,7 @@ ajax | true | Boolean | Specifies the submit mode, when set to true(default), su
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to be updated with ajax.
-onstart | null | String | Client side callback to execute before ajax request is begins.
+onstart | null | String | Client side callback to execute before ajax request begins.
 oncomplete | null | String | Client side callback to execute when ajax request is completed.
 onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/11_0_0/components/ajaxbehavior.md
+++ b/docs/11_0_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/11_0_0/components/commandbutton.md
+++ b/docs/11_0_0/components/commandbutton.md
@@ -31,7 +31,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/11_0_0/components/commandlink.md
+++ b/docs/11_0_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/11_0_0/components/hotkey.md
+++ b/docs/11_0_0/components/hotkey.md
@@ -30,7 +30,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/11_0_0/components/menuitem.md
+++ b/docs/11_0_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/11_0_0/components/poll.md
+++ b/docs/11_0_0/components/poll.md
@@ -29,7 +29,7 @@ update | @none | String | Component(s) to be updated with ajax.
 listener | null | MethodExpr | A method expression to invoke by polling.
 immediate | false | Boolean | Boolean value that determines the phaseId, when true actions are processed at apply_request_values, when false at invoke_application phase.
 async | false | Boolean | When set to true, ajax requests are not queued.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/11_0_0/components/remotecommand.md
+++ b/docs/11_0_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/11_0_0/components/splitbutton.md
+++ b/docs/11_0_0/components/splitbutton.md
@@ -31,7 +31,7 @@ ajax | true | Boolean | Specifies the submit mode, when set to true(default), su
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to be updated with ajax.
-onstart | null | String | Client side callback to execute before ajax request is begins.
+onstart | null | String | Client side callback to execute before ajax request begins.
 oncomplete | null | String | Client side callback to execute when ajax request is completed.
 onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/12_0_0/components/ajaxbehavior.md
+++ b/docs/12_0_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/12_0_0/components/commandbutton.md
+++ b/docs/12_0_0/components/commandbutton.md
@@ -31,7 +31,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/12_0_0/components/commandlink.md
+++ b/docs/12_0_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/12_0_0/components/hotkey.md
+++ b/docs/12_0_0/components/hotkey.md
@@ -30,7 +30,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/12_0_0/components/menuitem.md
+++ b/docs/12_0_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/12_0_0/components/poll.md
+++ b/docs/12_0_0/components/poll.md
@@ -29,7 +29,7 @@ update | @none | String | Component(s) to be updated with ajax.
 listener | null | MethodExpr | A method expression to invoke by polling.
 immediate | false | Boolean | Boolean value that determines the phaseId, when true actions are processed at apply_request_values, when false at invoke_application phase.
 async | false | Boolean | When set to true, ajax requests are not queued.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/12_0_0/components/remotecommand.md
+++ b/docs/12_0_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/12_0_0/components/splitbutton.md
+++ b/docs/12_0_0/components/splitbutton.md
@@ -31,7 +31,7 @@ SplitButton displays a command by default and additional ones in an overlay.
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/13_0_0/components/ajaxbehavior.md
+++ b/docs/13_0_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/13_0_0/components/commandbutton.md
+++ b/docs/13_0_0/components/commandbutton.md
@@ -32,7 +32,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/13_0_0/components/commandlink.md
+++ b/docs/13_0_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/13_0_0/components/hotkey.md
+++ b/docs/13_0_0/components/hotkey.md
@@ -30,7 +30,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/13_0_0/components/menuitem.md
+++ b/docs/13_0_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/13_0_0/components/poll.md
+++ b/docs/13_0_0/components/poll.md
@@ -29,7 +29,7 @@ update | @none | String | Component(s) to be updated with ajax.
 listener | null | MethodExpr | A method expression to invoke by polling.
 immediate | false | Boolean | Boolean value that determines the phaseId, when true actions are processed at apply_request_values, when false at invoke_application phase.
 async | false | Boolean | When set to true, ajax requests are not queued.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/13_0_0/components/remotecommand.md
+++ b/docs/13_0_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/13_0_0/components/splitbutton.md
+++ b/docs/13_0_0/components/splitbutton.md
@@ -32,7 +32,7 @@ SplitButton displays a command by default and additional ones in an overlay.
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/14_0_0/components/ajaxbehavior.md
+++ b/docs/14_0_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/14_0_0/components/commandbutton.md
+++ b/docs/14_0_0/components/commandbutton.md
@@ -32,7 +32,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/14_0_0/components/commandlink.md
+++ b/docs/14_0_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/14_0_0/components/hotkey.md
+++ b/docs/14_0_0/components/hotkey.md
@@ -30,7 +30,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/14_0_0/components/menuitem.md
+++ b/docs/14_0_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/14_0_0/components/poll.md
+++ b/docs/14_0_0/components/poll.md
@@ -38,7 +38,7 @@ onactivated | null | String | Javascript callback to execute when the poller is 
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 ondeactivated | null | String | Javascript callback to execute when the poller is deactivated. Return false to prevent poller from stopping.
 onerror | null | String | Javascript handler to execute when ajax request fails.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 partialSubmit | false | Boolean | Enables serialization of values belonging to the partially processed components only.
 partialSubmitFilter | null | String | Selector to use when partial submit is on, default is ":input" to select all descendant inputs of a partially processed components.

--- a/docs/14_0_0/components/remotecommand.md
+++ b/docs/14_0_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/14_0_0/components/splitbutton.md
+++ b/docs/14_0_0/components/splitbutton.md
@@ -32,7 +32,7 @@ SplitButton displays a command by default and additional ones in an overlay.
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/15_0_0/components/ajaxbehavior.md
+++ b/docs/15_0_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/15_0_0/components/commandbutton.md
+++ b/docs/15_0_0/components/commandbutton.md
@@ -32,7 +32,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/15_0_0/components/commandlink.md
+++ b/docs/15_0_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard Jakarta Faces commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/15_0_0/components/hotkey.md
+++ b/docs/15_0_0/components/hotkey.md
@@ -30,7 +30,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/15_0_0/components/menuitem.md
+++ b/docs/15_0_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/15_0_0/components/poll.md
+++ b/docs/15_0_0/components/poll.md
@@ -38,7 +38,7 @@ onactivated | null | String | Javascript callback to execute when the poller is 
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 ondeactivated | null | String | Javascript callback to execute when the poller is deactivated. Return false to prevent poller from stopping.
 onerror | null | String | Javascript handler to execute when ajax request fails.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 partialSubmit | false | Boolean | Enables serialization of values belonging to the partially processed components only.
 partialSubmitFilter | null | String | Selector to use when partial submit is on, default is ":input" to select all descendant inputs of a partially processed components.

--- a/docs/15_0_0/components/remotecommand.md
+++ b/docs/15_0_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/15_0_0/components/splitbutton.md
+++ b/docs/15_0_0/components/splitbutton.md
@@ -32,7 +32,7 @@ SplitButton displays a command by default and additional ones in an overlay.
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/7_0/components/ajaxbehavior.md
+++ b/docs/7_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@ AjaxBehavior is an extension to standard f:ajax.
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/7_0/components/commandbutton.md
+++ b/docs/7_0/components/commandbutton.md
@@ -29,7 +29,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/7_0/components/commandlink.md
+++ b/docs/7_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/7_0/components/hotkey.md
+++ b/docs/7_0/components/hotkey.md
@@ -29,7 +29,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/7_0/components/menuitem.md
+++ b/docs/7_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/7_0/components/poll.md
+++ b/docs/7_0/components/poll.md
@@ -27,7 +27,7 @@ update | @none | String | Component(s) to be updated with ajax.
 listener | null | MethodExpr | A method expression to invoke by polling.
 immediate | false | Boolean | Boolean value that determines the phaseId, when true actions are processed at apply_request_values, when false at invoke_application phase.
 async | false | Boolean | When set to true, ajax requests are not queued.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/7_0/components/remotecommand.md
+++ b/docs/7_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/7_0/components/splitbutton.md
+++ b/docs/7_0/components/splitbutton.md
@@ -29,7 +29,7 @@ ajax | true | Boolean | Specifies the submit mode, when set to true(default), su
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to be updated with ajax.
-onstart | null | String | Client side callback to execute before ajax request is begins.
+onstart | null | String | Client side callback to execute before ajax request begins.
 oncomplete | null | String | Client side callback to execute when ajax request is completed.
 onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/8_0/components/ajaxbehavior.md
+++ b/docs/8_0/components/ajaxbehavior.md
@@ -19,7 +19,7 @@
 | async | false | Boolean | When set to true, ajax requests are not queued. |
 | process | @this | String | Component(s) to process in partial request. |
 | update | @none | String | Component(s) to update with ajax. |
-| onstart | null | String | Client-side javascript callback to execute before ajax request is begins. |
+| onstart | null | String | Client-side javascript callback to execute before ajax request begins. |
 | oncomplete | null | String | Client-side javascript callback to execute when ajax request is completed. |
 | onsuccess | null | String | Client-side javascript callback to execute when ajax request succeeds. |
 | onerror | null | String | Client-side javascript callback to execute when ajax request fails. |

--- a/docs/8_0/components/commandbutton.md
+++ b/docs/8_0/components/commandbutton.md
@@ -29,7 +29,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | async | false | Boolean | When set to true, ajax requests are not queued.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/8_0/components/commandlink.md
+++ b/docs/8_0/components/commandlink.md
@@ -28,7 +28,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | process | @all | String | Component(s) to process partially instead of whole view.
 | ajax | true | Boolean | Specifies the submit mode, when set to true(default), submit would be made with Ajax.
 | update | @none | String | Component(s) to be updated with ajax.
-| onstart | null | String | Client side callback to execute before ajax request is begins.
+| onstart | null | String | Client side callback to execute before ajax request begins.
 | oncomplete | null | String | Client side callback to execute when ajax request is completed.
 | onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 | onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/8_0/components/hotkey.md
+++ b/docs/8_0/components/hotkey.md
@@ -29,7 +29,7 @@ immediate | false | Boolean | Boolean value that determines the phaseId, when tr
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | null | String | Component id(s) to process partially instead of whole view.
 update | null | String | Client side id of the component(s) to be updated after async partial submit request.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/8_0/components/menuitem.md
+++ b/docs/8_0/components/menuitem.md
@@ -32,7 +32,7 @@ async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Components to process partially instead of whole view.
 update | @none | String | Components to update after ajax request.
 disabled | false | Boolean | Disables the menuitem.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/8_0/components/poll.md
+++ b/docs/8_0/components/poll.md
@@ -27,7 +27,7 @@ update | @none | String | Component(s) to be updated with ajax.
 listener | null | MethodExpr | A method expression to invoke by polling.
 immediate | false | Boolean | Boolean value that determines the phaseId, when true actions are processed at apply_request_values, when false at invoke_application phase.
 async | false | Boolean | When set to true, ajax requests are not queued.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/8_0/components/remotecommand.md
+++ b/docs/8_0/components/remotecommand.md
@@ -27,7 +27,7 @@ name | null | String | Name of the command
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to update with ajax.
-onstart | null | String | Javascript handler to execute before ajax request is begins.
+onstart | null | String | Javascript handler to execute before ajax request begins.
 oncomplete | null | String | Javascript handler to execute when ajax request is completed.
 onsuccess | null | String | Javascript handler to execute when ajax request succeeds.
 onerror | null | String | Javascript handler to execute when ajax request fails.

--- a/docs/8_0/components/splitbutton.md
+++ b/docs/8_0/components/splitbutton.md
@@ -29,7 +29,7 @@ ajax | true | Boolean | Specifies the submit mode, when set to true(default), su
 async | false | Boolean | When set to true, ajax requests are not queued.
 process | @all | String | Component(s) to process partially instead of whole view.
 update | @none | String | Component(s) to be updated with ajax.
-onstart | null | String | Client side callback to execute before ajax request is begins.
+onstart | null | String | Client side callback to execute before ajax request begins.
 oncomplete | null | String | Client side callback to execute when ajax request is completed.
 onsuccess | null | String | Client side callback to execute when ajax request succeeds.
 onerror | null | String | Client side callback to execute when ajax request fails.

--- a/docs/vdldoc/p/ajax.html
+++ b/docs/vdldoc/p/ajax.html
@@ -191,7 +191,7 @@
                             <td class="colFirst"><a href="#onstart"><code>onstart</code></a></td><td class="colOne"><code>false</code></td><td class="colOne"><code>jakarta.el.ValueExpression</code>
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
-                    </td><td class="colLast">Client side callback execute before ajax request is begins.</td>
+                    </td><td class="colLast">Client side callback execute before ajax request begins.</td>
                         </tr>
                         <tr id="onsuccess" class="altColor">
                             <td class="colFirst"><a href="#onsuccess"><code>onsuccess</code></a></td><td class="colOne"><code>false</code></td><td class="colOne"><code>jakarta.el.ValueExpression</code>

--- a/docs/vdldoc/p/commandButton.html
+++ b/docs/vdldoc/p/commandButton.html
@@ -443,7 +443,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Client side callback to execute before ajax request is begins.
+                Client side callback to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="rowColor">

--- a/docs/vdldoc/p/commandLink.html
+++ b/docs/vdldoc/p/commandLink.html
@@ -387,7 +387,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Client side callback to execute before ajax request is begins.
+                Client side callback to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="altColor">

--- a/docs/vdldoc/p/hotkey.html
+++ b/docs/vdldoc/p/hotkey.html
@@ -242,7 +242,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Javascript handler to execute before ajax request is begins.
+                Javascript handler to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="altColor">

--- a/docs/vdldoc/p/menuitem.html
+++ b/docs/vdldoc/p/menuitem.html
@@ -324,7 +324,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Javascript handler to execute before ajax request is begins.
+                Javascript handler to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="altColor">

--- a/docs/vdldoc/p/poll.html
+++ b/docs/vdldoc/p/poll.html
@@ -250,7 +250,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Javascript handler to execute before ajax request is begins.
+                Javascript handler to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="rowColor">

--- a/docs/vdldoc/p/remoteCommand.html
+++ b/docs/vdldoc/p/remoteCommand.html
@@ -235,7 +235,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Javascript handler to execute before ajax request is begins.
+                Javascript handler to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="rowColor">

--- a/docs/vdldoc/p/splitButton.html
+++ b/docs/vdldoc/p/splitButton.html
@@ -489,7 +489,7 @@
                                 <br>
                                 (<i>must evaluate to </i><code>java.lang.String</code>)
                     </td><td class="colLast">
-                Client side callback to execute before ajax request is begins.
+                Client side callback to execute before ajax request begins.
             </td>
                         </tr>
                         <tr id="onsuccess" class="altColor">

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -363,7 +363,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
-            <description>Client side callback execute before ajax request is begins.</description>
+            <description>Client side callback execute before ajax request begins.</description>
             <name>onstart</name>
             <required>false</required>
             <type>java.lang.String</type>
@@ -6553,7 +6553,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Client side callback to execute before ajax request is begins.]]>
+                <![CDATA[Client side callback to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>
@@ -7037,7 +7037,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Client side callback to execute before ajax request is begins.]]>
+                <![CDATA[Client side callback to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>
@@ -12305,7 +12305,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Javascript handler to execute before ajax request is begins.]]>
+                <![CDATA[Javascript handler to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>
@@ -17774,7 +17774,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Javascript handler to execute before ajax request is begins.]]>
+                <![CDATA[Javascript handler to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>
@@ -21156,7 +21156,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Javascript handler to execute before ajax request is begins.]]>
+                <![CDATA[Javascript handler to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>
@@ -21831,7 +21831,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Javascript handler to execute before ajax request is begins.]]>
+                <![CDATA[Javascript handler to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>
@@ -26833,7 +26833,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Client side callback to execute before ajax request is begins.]]>
+                <![CDATA[Client side callback to execute before ajax request begins.]]>
             </description>
             <name>onstart</name>
             <required>false</required>


### PR DESCRIPTION
Replace common documentation typo "is begins" with "begins"